### PR TITLE
Podpowiadanie wyszukiwania

### DIFF
--- a/weather-app/src/app/api.service.ts
+++ b/weather-app/src/app/api.service.ts
@@ -27,7 +27,7 @@ export class ApiService {
     };
   }
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) { }
 
   getCityInfo(name: string): Observable<City[]> {
     return this.http.get<City[]>(`${this.cityUrl}${name}`).pipe(
@@ -39,6 +39,13 @@ export class ApiService {
     return this.http.get(`${this.weatherUrl}${id}`).pipe(
       tap((_) => console.log("fetched Weather data")),
       catchError(this.handleError("getWeather", []))
+    );
+  }
+  getCitiesInfo(): Observable<City[]> {
+
+    return this.http.get<City[]>(`${this.cityUrl}a`).pipe(
+      tap(_ => console.log("fetched Cities Info")),
+      catchError(this.handleError<City[]>("getCitiesInfo", []))
     );
   }
 }

--- a/weather-app/src/app/app.module.ts
+++ b/weather-app/src/app/app.module.ts
@@ -16,6 +16,12 @@ import { WeatherDisplayComponent } from "./weather-display/weather-display.compo
 import { MatListModule } from "@angular/material/list";
 import { MatDividerModule } from "@angular/material/divider";
 
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
+
+
 @NgModule({
   declarations: [AppComponent, SearchComponent, WeatherDisplayComponent],
   imports: [
@@ -28,8 +34,12 @@ import { MatDividerModule } from "@angular/material/divider";
     BrowserAnimationsModule,
     MatListModule,
     MatDividerModule,
+    MatAutocompleteModule,
+    FormsModule,
+    ReactiveFormsModule,
   ],
-  providers: [ApiService],
+  providers: [ApiService,
+    { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'fill' } }],
   bootstrap: [AppComponent],
 })
-export class AppModule {}
+export class AppModule { }

--- a/weather-app/src/app/search/search.component.css
+++ b/weather-app/src/app/search/search.component.css
@@ -5,6 +5,7 @@ button#button1 {
 }
 #input {
   width: 77%;
+  height: 50px;
   margin-left: 5%;
 }
 div#display {

--- a/weather-app/src/app/search/search.component.html
+++ b/weather-app/src/app/search/search.component.html
@@ -1,19 +1,17 @@
-<mat-form-field appearance="fill" id="input">
+<mat-form-field id="input">
   <mat-label>Wyszukaj pogodę dla miasta</mat-label>
-  <input matInput #cityName />
+  <input matInput [matAutocomplete]="auto" [formControl]="control" #cityName formControlName="stateGroup" />
+
+  <mat-autocomplete #auto="matAutocomplete">
+    <mat-option *ngFor="let cityName of filteredCitiesNames | async" [value]="cityName">
+      {{cityName}}
+    </mat-option>
+  </mat-autocomplete>
 </mat-form-field>
 
-<button
-  mat-raised-button
-  color="primary"
-  id="button1"
-  (click)="getCityInfo(cityName.value)"
->
+<button mat-raised-button color="primary" id="button1" (click)="getCityInfo(cityName.value)">
   Wyszukaj
 </button>
 <div id="display">
-  <app-weather-display
-    [title]="title"
-    [weatherTable]="weatherTable"
-  ></app-weather-display>
+  <app-weather-display [title]="title" [weatherTable]="weatherTable"></app-weather-display>
 </div>

--- a/weather-app/src/app/search/search.component.ts
+++ b/weather-app/src/app/search/search.component.ts
@@ -2,10 +2,13 @@ import { Component, OnInit } from "@angular/core";
 import { ApiService } from "../api.service";
 
 import { Observable } from "rxjs";
+import { startWith, map } from 'rxjs/operators';
 
 import { Weather } from "../weather";
 
 import { City } from "../city";
+import { FormControl } from '@angular/forms';
+
 
 @Component({
   selector: "app-search",
@@ -15,7 +18,12 @@ import { City } from "../city";
 export class SearchComponent implements OnInit {
   title: string;
   weatherTable: Weather[];
-  constructor(private api: ApiService) {}
+
+  control = new FormControl();
+  CitiesNames: string[] = [];
+  filteredCitiesNames: Observable<string[]>;
+
+  constructor(private api: ApiService) { }
 
   getWeather(id: number): void {
     this.api.getWeather(id).subscribe((data: any) => {
@@ -33,6 +41,33 @@ export class SearchComponent implements OnInit {
       this.getWeather(woeid);
     });
   }
+  getCitiesInfo() {
+    this.api.getCitiesInfo().subscribe((data: City[]) => {
+      this.CitiesNames = data.map(r => r.title);
+      console.log(this.CitiesNames);
+    });
+  }
 
-  ngOnInit(): void {}
+  filter() {
+    this.filteredCitiesNames = this.control.valueChanges.pipe(
+      startWith(''),
+      map(value => this._filter(value))
+
+    );
+  }
+
+  ngOnInit(): void {
+    this.getCitiesInfo();
+    this.filter();
+  }
+
+  private _filter(value: string): string[] {
+    const filterValue = this._normalizeValue(value);
+    return this.CitiesNames.filter(cityName => this._normalizeValue(cityName).includes(filterValue));
+  }
+  private _normalizeValue(value: string): string {
+    return value.toLowerCase().replace(/\s/g, '');
+  }
+
+
 }


### PR DESCRIPTION
Zamieszczam w repozytorium podpowiadanie wyszukiwania, które nie jest kompletne, ponieważ nie ma w nim wszystkich nazw miast, a tylko te, które zawierają samogłoskę "a". Można by było pokombinować  z wyszukiwaniem ściągając dane z wielu linków np. 
www.metaweather.com/api/location/search/?query=a
www.metaweather.com/api/location/search/?query=e
i wtedy odfiltrować te dane z tablic obiektów i dodać do jednej tablicy. Więc może o tym pomyślę. 